### PR TITLE
Bring forward contributors page content from previous PR

### DIFF
--- a/src/pages/contributors.tsx
+++ b/src/pages/contributors.tsx
@@ -1,0 +1,92 @@
+import Image from 'next/image'
+import { Inter } from 'next/font/google'
+import React from "react";
+import { useTheme } from "@mui/material/styles";
+import { Paper, Card, Typography, Link } from "@mui/material";
+import styles from '@/styles/Contributors.module.css';
+const inter = Inter({ subsets: ['latin'] })
+
+const project_ricotta_contributors = [
+    {
+        cname: "Danielle Gellis",
+        contrib_url: "https://github.com/danisyellis"
+    },
+    {
+        cname: "Vale Gilbert",
+        contrib_url: "https://github.com/urbanengr"
+    },
+    {
+        cname: "Mike Kantzer",
+        contrib_url: "https://github.com/mkantzer"
+    },
+    {
+        cname: "Matt Kuznicki",
+        contrib_url: "https://github.com/mattkuznicki-ll"
+    },
+    {
+        cname: "Alfredo Luque",
+        contrib_url: "https://github.com/iamthebot"
+    },
+    {
+        cname: "Pat Mejia",
+        contrib_url: "https://github.com/patmejia"
+    },
+    {
+        cname: "Emma Nolan",
+        contrib_url: "https://github.com/emmanolan"
+    },
+    {
+        cname: "Jonathan Roemer",
+        contrib_url: "https://github.com/pid1"
+    },
+    {
+        cname: "Esther Rose",
+        contrib_url: "https://github.com/codarose"
+    },
+    {
+        cname: "Allyson S.",
+        contrib_url: "https://github.com/allyson-s-code"
+    }
+];
+
+export default function Contributors() {
+  const theme = useTheme();
+  return (
+    <main>
+      <header>
+        <Image src={"logo-vrt1.png"} alt="Lasagna Love logo" width={90} height={79} className="logo" />
+      </header>
+
+      <h1>Lasagna Love Project Ricotta Contributors</h1>
+
+      <div>
+        <Typography>
+          <p>
+            Thank you to all who were so generous with their time and skills. We&apos;ve
+            listed the Contributors below. Clicking on their names will direct you to
+            their contribution page.
+          </p>
+          <h2>Contributors</h2>
+          <div className="contributors">
+              <div className="styles.cbox">
+
+                { project_ricotta_contributors.map((item, i) => {
+                    return (
+                    <div className="cname" key={i}>
+                        <a href={item.contrib_url}>{item.cname}</a>
+                    </div>
+                    );
+                })}
+
+            </div>
+          </div>
+          <p>
+            If you were a Contributor and your name is not listed, please open a pull request
+            to enter your name and contribution. We want to honor <i>all</i>
+            of our Contributors.
+          </p>
+        </Typography>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/contributors.tsx
+++ b/src/pages/contributors.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 import { Inter } from 'next/font/google'
 import React from "react";
 import { useTheme } from "@mui/material/styles";
-import { Paper, Card, Typography, Link } from "@mui/material";
+import { Typography } from "@mui/material";
 import styles from '@/styles/Contributors.module.css';
 const inter = Inter({ subsets: ['latin'] })
 
@@ -50,43 +50,39 @@ const project_ricotta_contributors = [
 ];
 
 export default function Contributors() {
-  const theme = useTheme();
-  return (
-    <main>
-      <header>
-        <Image src={"logo-vrt1.png"} alt="Lasagna Love logo" width={90} height={79} className="logo" />
-      </header>
+    const theme = useTheme();
+    return (
+        <main>
+            <header>
+                <Image src={"logo-vrt1.png"} alt="Lasagna Love logo" width={90} height={79} className="logo" />
+            </header>
 
-      <h1>Lasagna Love Project Ricotta Contributors</h1>
+            <h1>Lasagna Love Project Ricotta Contributors</h1>
 
-      <div>
-        <Typography>
-          <p>
-            Thank you to all who were so generous with their time and skills. We&apos;ve
-            listed the Contributors below. Clicking on their names will direct you to
-            their contribution page.
-          </p>
-          <h2>Contributors</h2>
-          <div className="contributors">
-              <div className="styles.cbox">
-
-                { project_ricotta_contributors.map((item, i) => {
-                    return (
-                    <div className="cname" key={i}>
-                        <a href={item.contrib_url}>{item.cname}</a>
-                    </div>
-                    );
-                })}
-
+            <div className="styles.cbox">
+                <Typography>
+                    <p>
+                        Thank you to all who were so generous with their time and skills. We&apos;ve
+                        listed the Contributors below. Clicking on their names will direct you to
+                        their contribution page.
+                    </p>
+                    <h2>Contributors</h2>
+                    <Typography>
+                        {project_ricotta_contributors.map((item, i) => {
+                            return (
+                                <div className="cname" key={i}>
+                                    <a href={item.contrib_url}>{item.cname}</a>
+                                </div>
+                            );
+                        })}
+                    </Typography>
+                    <p>
+                        If you were a Contributor and your name is not listed, please open a pull request
+                        to enter your name and contribution. We want to honor <i>all</i>
+                        of our Contributors.
+                    </p>
+                </Typography>
             </div>
-          </div>
-          <p>
-            If you were a Contributor and your name is not listed, please open a pull request
-            to enter your name and contribution. We want to honor <i>all</i>
-            of our Contributors.
-          </p>
-        </Typography>
-      </div>
-    </main>
-  );
+        </main>
+    );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -89,6 +89,12 @@ export default function Home() {
           </Link>
         </Typography>
       </div>
+
+      <div>
+        <Typography>
+          <Link href="contributors">We extend a special thank you to all our Project Ricotta contributors!</Link>
+        </Typography>
+      </div>
     </main>
   );
 }

--- a/src/styles/Contributors.module.css
+++ b/src/styles/Contributors.module.css
@@ -1,10 +1,10 @@
 /* List of Project Ricotta contributors */
 .cbox {
-    box-sizing: border-box;
-    padding: 1rem;
-    font-size: 1.1rem;
-    font-weight: 700;
-    margin-bottom: 10px;
-    display: inline-block;
-    position: relative;
+  box-sizing: border-box;
+  padding: 1rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-bottom: 10px;
+  display: inline-block;
+  position: relative;
 }

--- a/src/styles/Contributors.module.css
+++ b/src/styles/Contributors.module.css
@@ -1,0 +1,10 @@
+/* List of Project Ricotta contributors */
+.cbox {
+    box-sizing: border-box;
+    padding: 1rem;
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin-bottom: 10px;
+    display: inline-block;
+    position: relative;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,6 +25,15 @@ body,
   -moz-osx-font-smoothing: grayscale;
 }
 
+h1 {
+  font-size: 24px;
+  font-style: normal;
+  font-variant: normal;
+  font-weight: 700;
+  line-height: 26.4px;
+  text-align: center;
+}
+
 code {
   font-family:
     source-code-pro,


### PR DESCRIPTION
This brings in a contributors page for the Project Ricotta contributors, as envisioned in https://github.com/Lasagna-Love-Portal/project-ricotta/pull/20. This PR adds the page as a new contributors page with some very minimal styling and with an initial list of known contributors.

This does not bring forward the general styling CSS from that PR, as we'll be developing some site-wide CSS and styling later.
I also believe styling isn't being picked up correctly for at least some elements, that can be addressed later.

Includes very basic link from welcome landing page.