### PR TITLE
Basic implementation for JWT refresh token workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ We encourage feedback and suggestions on pull requests to help make Project Rico
 
 We encourage practicality over perfection. We expect our projects will iterate towards better over time and especially encourage contributions that advance Project Ricotta along the journey to being better.
 
-We encourage making issues in Github for suggestions and ideas.
+We encourage making issues in GitHub for suggestions and ideas.
 
 We encourage pull request reviewers to merge pull requests when they give approvals and they're able. Contributors who've opened pull requests and see an approval are able to merge and close their own pull requests but we prefer reviewer to merge and close wherever possible.
 

--- a/src/services/auth-header.ts
+++ b/src/services/auth-header.ts
@@ -1,6 +1,6 @@
 export default function authHeader() {
-    const userToken = localStorage.getItem("userToken");
-    if (userToken) {
+    let userToken = localStorage.getItem("bechamel_access_token");
+    if (localStorage.getItem("bechamel_access_token")) {
         return { Authorization: 'Bearer ' + userToken };
     } else {
         return { Authorization: '' };

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -7,21 +7,54 @@ class AuthService {
     async login(username: string, password: string) {
         try {
             let loginResponse = await axios.post(API_URL + "login", { username, password });
-            if (loginResponse.status == 200 && loginResponse.data['token']) {
-                if (localStorage.getItem("userToken"))
+            if (loginResponse.status == 200 &&
+                loginResponse.data['access_token'] &&
+                loginResponse.data['refresh_token']) {
+                if (localStorage.getItem("bechamel_access_token"))
                 {
-                    localStorage.removeItem("userToken");
+                    localStorage.removeItem("bechamel_access_token");
                 }
-                localStorage.setItem("userToken", loginResponse.data['token']);
-                return loginResponse.data['token'];
+                if (localStorage.getItem("bechamel_refresh_token"))
+                {
+                    localStorage.removeItem("bechamel_refresh_token");
+                }
+                localStorage.setItem("bechamel_access_token", loginResponse.data['access_token']);
+                localStorage.setItem("bechamel_refresh_token", loginResponse.data['refresh_token']);
+
+                return loginResponse.data['access_token'];
             }
             else if (loginResponse.status == 401) { // unauthorized
                 console.error("Invalid username and password supplied.");
                 alert("Invalid username and password supplied.");
             }
-            else {
-                alert("Returned status: " + loginResponse.status + "\n" +
-                    "Returned data: " + JSON.stringify(loginResponse.data));
+        } catch (error) {
+            console.error(error);
+            alert("Error: " + error);
+        }
+    }
+
+    async refresh(refreshToken: string) {
+        try {
+            let loginResponse = await axios.post(API_URL + "login", { "refresh_token" : refreshToken });
+            if (loginResponse.status == 200 &&
+                loginResponse.data['access_token'] &&
+                loginResponse.data['refresh_token']) {
+                if (localStorage.getItem("bechamel_access_token"))
+                {
+                    localStorage.removeItem("bechamel_access_token");
+                }
+                if (localStorage.getItem("bechamel_refresh_token"))
+                {
+                    localStorage.removeItem("bechamel_refresh_token");
+                }
+                localStorage.setItem("bechamel_access_token", loginResponse.data['access_token']);
+                localStorage.setItem("bechamel_refresh_token", loginResponse.data['refresh_token']);
+
+                return loginResponse.data['access_token'];
+            }
+            else if (loginResponse.status == 401) { // unauthorized
+                console.error("Refresh token not authorized, HTTP 401 returned");
+                alert("Refresh token not authorized, HTTP 401 returned");
             }
         } catch (error) {
             console.error(error);
@@ -30,7 +63,8 @@ class AuthService {
     }
 
     logout() {
-        localStorage.removeItem("userToken");
+        localStorage.removeItem("bechamel_access_token");
+        localStorage.removeItem("bechamel_refresh_token");
         alert("You have successfully logged out.")
     }
 }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,27 +1,30 @@
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
 
 // TODO: un hard-code the URL string, obtain from elsewhere
 const API_URL = "http://localhost:8080/";
 
 class AuthService {
+    private storeTokens(loginResponse : AxiosResponse) {
+        if (localStorage.getItem("bechamel_access_token"))
+        {
+            localStorage.removeItem("bechamel_access_token");
+        }
+        if (localStorage.getItem("bechamel_refresh_token"))
+        {
+            localStorage.removeItem("bechamel_refresh_token");
+        }
+        localStorage.setItem("bechamel_access_token", loginResponse.data['access_token']);
+        localStorage.setItem("bechamel_refresh_token", loginResponse.data['refresh_token']);
+    }
+
     async login(username: string, password: string) {
         try {
             let loginResponse = await axios.post(API_URL + "login", { username, password });
             if (loginResponse.status == 200 &&
                 loginResponse.data['access_token'] &&
                 loginResponse.data['refresh_token']) {
-                if (localStorage.getItem("bechamel_access_token"))
-                {
-                    localStorage.removeItem("bechamel_access_token");
-                }
-                if (localStorage.getItem("bechamel_refresh_token"))
-                {
-                    localStorage.removeItem("bechamel_refresh_token");
-                }
-                localStorage.setItem("bechamel_access_token", loginResponse.data['access_token']);
-                localStorage.setItem("bechamel_refresh_token", loginResponse.data['refresh_token']);
-
-                return loginResponse.data['access_token'];
+                    this.storeTokens(loginResponse);
+                    return loginResponse.data['access_token'];
             }
             else if (loginResponse.status == 401) { // unauthorized
                 console.error("Invalid username and password supplied.");
@@ -39,18 +42,8 @@ class AuthService {
             if (loginResponse.status == 200 &&
                 loginResponse.data['access_token'] &&
                 loginResponse.data['refresh_token']) {
-                if (localStorage.getItem("bechamel_access_token"))
-                {
-                    localStorage.removeItem("bechamel_access_token");
-                }
-                if (localStorage.getItem("bechamel_refresh_token"))
-                {
-                    localStorage.removeItem("bechamel_refresh_token");
-                }
-                localStorage.setItem("bechamel_access_token", loginResponse.data['access_token']);
-                localStorage.setItem("bechamel_refresh_token", loginResponse.data['refresh_token']);
-
-                return loginResponse.data['access_token'];
+                    this.storeTokens(loginResponse);
+                    return loginResponse.data['access_token'];
             }
             else if (loginResponse.status == 401) { // unauthorized
                 console.error("Refresh token not authorized, HTTP 401 returned");

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,5 +1,7 @@
-import axios from 'axios';
+import axios, { AxiosError, AxiosResponse } from 'axios';
+import AuthService from './auth.service';
 import authHeader from './auth-header';
+import { ref } from 'yup';
 
 // TODO: un hard-code the URL string, obtain from elsewhere
 const API_URL = 'http://localhost:8080/';
@@ -10,8 +12,25 @@ class UserService {
             let response = await axios.get(API_URL + 'profile', { headers: authHeader() });
             return response.data;
         } catch (error) {
-            console.error(error);
-            alert("Error: " + error);
+            if (axios.isAxiosError(error)) {
+                const axiosErr = error as AxiosError;
+                if (axiosErr.response?.status == 401) {
+                    let refreshToken = localStorage.getItem("bechamel_refresh_token");
+                    if (refreshToken) {
+                        console.log("HTTP 401 returned from GET /profile, attempting to re-login with refresh token.");
+                        await AuthService.refresh(refreshToken);
+                        // Need to handle error, ideal would be to call recursively... but having issues
+                        let retryResponse = await axios.get(API_URL + 'profile', { headers: authHeader() });
+                        return retryResponse.data;
+                    }
+                } else {
+                    console.error(error);
+                    alert("Error: " + error);
+                }
+            } else {
+                console.error(error);
+                alert("Error: " + error);
+            }
         }
     }
 }

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -17,7 +17,7 @@ class UserService {
                 if (axiosErr.response?.status == 401) {
                     let refreshToken = localStorage.getItem("bechamel_refresh_token");
                     if (refreshToken) {
-                        console.log("HTTP 401 returned from GET /profile, attempting to re-login with refresh token.");
+                        console.info("HTTP 401 returned from GET /profile, attempting to re-login with refresh token.");
                         await AuthService.refresh(refreshToken);
                         // Need to handle error, ideal would be to call recursively... but having issues
                         let retryResponse = await axios.get(API_URL + 'profile', { headers: authHeader() });


### PR DESCRIPTION
To prevent users from having to repeatedly login as their JWT access tokens expire,
https://github.com/Lasagna-Love-Portal/bechamel-api/pull/18 extends the Bechamel API
to generate and return refresh_token JWTs in addition to access_token JWTs in its /login API.

**NOTE**: requires changes in https://github.com/Lasagna-Love-Portal/bechamel-api/pull/18 to function properly.

This PR contains updates to check for an initial HTTP 401 Unauthorized in the GET /profile call,
and adds logic to use the refresh token if present to attempt to refresh the access token.
Doing so nets a new access token without user intervention, allowing for invisible re-authentication
for the valid time of the refresh tokens.

Best considered as a starting point for this logic, the author is reasonably sure there are refinements
and improvements that can be proposed and implemented.

Also addresses the linter error in https://github.com/Lasagna-Love-Portal/project-ricotta/issues/39

There are two classes of linter issues in PR:
* A duplicated code issue that I don't agree with re: excessive duplication, other opinions welcomed
* Linter configuration issue for a trio of TypeScript files as described in https://github.com/Lasagna-Love-Portal/project-ricotta/issues/42. Any help with this would be appreciated, please discuss in that issue.