### PR TITLE
Beginnings of navbar, main landing page, data model & other touchups

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -8,7 +8,7 @@ name: Lint Code Base
 
 on:
   push:
-    branches: ["dev", "main"]
+    branches: ["dev", "main", "mattkuznicki-ll/add-main-landing-area"]
   pull_request:
     branches: ["dev", "main"]
 jobs:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -79,6 +79,8 @@ Where [path-to-project] is the full path to your project.
 ## Architecture
 
 Software Stack:
-- react
 - next.js
-- docker
+- React
+- TypeScript
+- JavaScript
+- Docker

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint": "8.39.0",
         "eslint-config-next": "13.3.1",
         "formik": "^2.2.9",
+        "jwt-decode": "^3.1.2",
         "next": "13.3.1",
         "postcss": "8.4.23",
         "react": "18.2.0",
@@ -3298,6 +3299,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint": "8.39.0",
     "eslint-config-next": "13.3.1",
     "formik": "^2.2.9",
+    "jwt-decode": "^3.1.2",
     "next": "13.3.1",
     "postcss": "8.4.23",
     "react": "18.2.0",

--- a/src/components/main_header.tsx
+++ b/src/components/main_header.tsx
@@ -1,0 +1,66 @@
+import Image from "next/image";
+import { Inter } from "next/font/google";
+import React from "react";
+import { Box, Button, Link, Menu, MenuItem } from '@mui/material'
+import { useTheme } from "@mui/material/styles";
+import styles from "@/styles/MainHeader.module.css";
+import AuthService from "@/services/auth.service";
+const inter = Inter({ subsets: ["latin"] });
+
+export default function MainHeader () {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+// Need to verify we have a JWT with a username, immediately go back to login page if we don't.
+// This is faster than verifying an active login since it doesn't hit the API at all
+  const username = AuthService.getCurrentUsername();
+  if (username === "") {
+    alert("You do not appear to be logged in.\n Redirecting to login page.");
+    window.location.replace("/login");
+  }
+
+  const theme = useTheme();
+
+  return (
+    <Box className={styles["main-header"]}>
+      <Image
+        src={"logo-vrt1.png"}
+        alt="Lasagna Love logo"
+        width={90}
+        height={79}
+        className="logo"
+      />
+      <Button
+        id="basic-button"
+        aria-controls={open ? 'basic-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+      >
+        {username}
+      </Button>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': 'basic-button',
+        }}
+      >
+        <MenuItem onClick={handleClose}>
+          <Link href="/profile">Profile</Link>
+        </MenuItem>
+        <MenuItem onClick={handleClose}>
+          <Link href="/logout">Logout</Link>
+        </MenuItem>
+      </Menu>
+    </Box>
+  );
+}

--- a/src/model/Attestations.d.ts
+++ b/src/model/Attestations.d.ts
@@ -1,0 +1,8 @@
+export interface Attestations {
+    user_is_eighteen: boolean,
+    user_accepted_email_communications: boolean,
+    requester_accepted_liability_release: string,
+    volunteer_accepted_indemnity_waiver: string,
+    volunteer_accepted_volunteer_terms: string,
+    volunteer_completed_safety_training: string,
+};

--- a/src/model/Profile.d.ts
+++ b/src/model/Profile.d.ts
@@ -26,6 +26,6 @@ export interface Profile {
     paused: boolean,
     paused_end_date: string,
     attestations: Attestations,
-    //	RecipientInfo           *LasagnaLoveRecipientInfo `json:"recipient_info,omitempty"`
-    //	VolunteerInfo           *LasagnaLoveVolunteerInfo `json:"volunteer_info,omitempty"`
+    recipient_info: RecipientInfo,
+    volunteer_info: VolunteerInfo
 }

--- a/src/model/Profile.d.ts
+++ b/src/model/Profile.d.ts
@@ -1,0 +1,31 @@
+import { Attestations } from 'Attestations';
+import { VolunteerInfo } from './VolunteerInfo';
+import { RecipientInfo } from './RecipientInfo';
+
+export interface Profile {
+    id: number,
+    roles: string[],
+    username: string,
+    // password can be supplied in a PATCH but will not be returned by the Bechamel API
+    given_name: string,
+    middle_or_maiden_name: string,
+    family_name: string,
+    email: string,
+    email_validated: boolean,
+    creation_time: string,
+    last_update_time: string,
+    street_address: string[],
+    city: string,
+    state_or_province: string,
+    postal_code: string,
+    home_phone: string,
+    mobile_phone: string,
+    mobile_contact_permission: boolean,
+    news_updates_permission: boolean,
+    active: boolean,
+    paused: boolean,
+    paused_end_date: string,
+    attestations: Attestations,
+    //	RecipientInfo           *LasagnaLoveRecipientInfo `json:"recipient_info,omitempty"`
+    //	VolunteerInfo           *LasagnaLoveVolunteerInfo `json:"volunteer_info,omitempty"`
+}

--- a/src/model/RecipientInfo.d.ts
+++ b/src/model/RecipientInfo.d.ts
@@ -1,0 +1,7 @@
+export interface RecipientInfo {
+	adult_count: number,
+	child_count: number,
+	learned_about_from: string,
+	last_delivery_received: string,
+	dietary_restrictions: string[]
+}

--- a/src/model/VolunteerInfo.d.ts
+++ b/src/model/VolunteerInfo.d.ts
@@ -1,0 +1,13 @@
+export interface VolunteerInfo {
+	birthday: string,
+	gender_identity: string,
+	volunteering_with: string,
+	employer: string,
+	facebook_name: string,
+	max_travel_distance: number,
+	families_per_delivery: number,
+	allowable_dietary_restrictions: string[],
+	accomodates_extra_requests: boolean,
+	show_completed_requests: boolean,
+	available_schedule: string[],
+}

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -1,0 +1,27 @@
+import { Inter } from "next/font/google";
+import React from "react";
+import { useTheme } from "@mui/material/styles";
+import { Typography } from "@mui/material";
+const inter = Inter({ subsets: ["latin"] });
+
+// The main header fetches the current username out of the client-side
+// stored JWT, so cannot be server-side prerendered
+import dynamic from "next/dynamic";
+const MainHeader = dynamic(() => import("@/components/main_header"), {
+  ssr: false,
+});
+
+export default function Landing() {
+  const theme = useTheme();
+
+  return (
+    <main className="body">
+      <div>
+        <MainHeader />
+        <Typography variant="h1">
+          Lasagna Love portal - main landing page
+        </Typography>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -13,13 +13,6 @@ interface Values {
     password: string;
 }
 
-type State = {
-    username: string,
-    password: string,
-    loading: boolean,
-    message: string
-  };
-
 export default function Login() {
     const theme = useTheme();
     return (
@@ -38,17 +31,13 @@ export default function Login() {
                     username: '',
                     password: ''
                 }}
-                onSubmit={(
+                onSubmit={ async (
                     values: Values,
                     { setSubmitting }: FormikHelpers<Values>
                 ) => {
-                    setTimeout(() => {
-                        AuthService.login(values.username, values.password);
-                        setSubmitting(false);
-                        // TODO: redirect to a main page or similar
-                        // this is a placeholder to show going somewhere
-                        window.location.replace("/profile");
-                    }, 500);
+                    await AuthService.login(values.username, values.password);
+                    // TODO: better handle login errors
+                    window.location.replace("/landing");
                 }}
             >
                 <Form>

--- a/src/pages/logout.tsx
+++ b/src/pages/logout.tsx
@@ -1,0 +1,41 @@
+import Image from "next/image";
+import { Inter } from "next/font/google";
+import React from "react";
+import { useTheme } from "@mui/material/styles";
+import styles from "@/styles/Welcome.module.css";
+import AuthService from "@/services/auth.service";
+const inter = Inter({ subsets: ["latin"] });
+
+export default function Profile() {
+    const [didLogout, setLoggedOut] = React.useState(false);
+    let statusString : string = "";
+
+    React.useEffect(() => {
+        if (AuthService.logout()) {
+            setLoggedOut(true);
+        }
+    }, []);
+    if (didLogout) {
+        statusString = "Logged out";        
+    } else {
+        statusString = "Error logging out";
+    }
+    const theme = useTheme();
+
+    return (
+        <main className={styles["welcome-screen"]}>
+            <header className={styles["welcome-header"]}>
+                <Image
+                    src={"logo-vrt1.png"}
+                    alt="Lasagna Love logo"
+                    width={90}
+                    height={79}
+                    className="logo"
+                />
+            </header>
+            <div>
+                <b>{statusString}</b>
+            </div>
+        </main>
+    );
+}

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,23 +1,32 @@
-import Image from "next/image";
 import { Inter } from "next/font/google";
 import React from "react";
-import { Button } from '@mui/material'
+import { Button, Card, CardContent, Typography } from '@mui/material'
 import { useTheme } from "@mui/material/styles";
 import styles from "@/styles/Welcome.module.css";
-import { Formik, Field, Form, FormikHelpers } from "formik";
 import UserService from "@/services/user.service";
+import { Attestations } from '@/model/Attestations';
+import { VolunteerInfo } from '@/model/VolunteerInfo';
+import { RecipientInfo } from '@/model/RecipientInfo';
+import { Profile } from '@/model/Profile';
 const inter = Inter({ subsets: ["latin"] });
 
+// The main header fetches the current username out of the client-side
+// stored JWT, so cannot be server-side prerendered
+import dynamic from "next/dynamic";
+const MainHeader = dynamic(() => import("@/components/main_header"), {
+  ssr: false,
+});
+
 export default function Profile() {
-    const [data, setData] = React.useState(null);
+    const [userProfile, setUserProfile] = React.useState<Profile | undefined>(undefined);
     const [isLoading, setLoading] = React.useState(false);
     let statusString : string = "";
 
     React.useEffect(() => {
         setLoading(true);
         UserService.getCurrentUserProfile()
-        .then((data) => {
-            setData(data);
+        .then((userProfile) => {
+            setUserProfile(userProfile);
             setLoading(false);
         }, (error) => {
             alert("Profile fetch error: " + error);
@@ -26,29 +35,42 @@ export default function Profile() {
     }, []);
 
     if (isLoading) statusString = "Loading..."
-    if (!data) {
+    if (!userProfile) {
         statusString = "No profile data obtained."
     } else {
         statusString = "";
     }
-    const theme = useTheme();
 
+    const theme = useTheme();
 
     return (
         <main className={styles["welcome-screen"]}>
-            <header className={styles["welcome-header"]}>
-                <Image
-                    src={"logo-vrt1.png"}
-                    alt="Lasagna Love logo"
-                    width={90}
-                    height={79}
-                    className="logo"
-                />
-            </header>
             <div>
-                <b>{data === null ? statusString :
-                    "Current logged in user profile: " + JSON.stringify(data)}</b>
+                <MainHeader />
             </div>
+            <Card>
+                <CardContent>
+                    <Typography variant="h1">
+                        Current logged-in user
+                    </Typography>
+                    <Typography variant="h2">
+                        Some basic user info (not all)
+                    </Typography>
+                    <Typography>
+                        User ID: {userProfile?.id}<br />
+                        Username: {userProfile?.username}<br />
+                        User roles: {userProfile?.roles}<br />
+                        First name: {userProfile?.given_name}<br />
+                        Last name: {userProfile?.family_name}<br />
+                    </Typography>
+                    <Typography variant="h2">
+                        User Attestations:
+                    </Typography>
+                    <Typography>
+                        User is eighteen or older: {userProfile?.attestations.user_is_eighteen ? "true" : "false"} <br />
+                    </Typography>
+                </CardContent>
+            </Card>
         </main>
     );
 }

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -17,6 +17,31 @@ const MainHeader = dynamic(() => import("@/components/main_header"), {
   ssr: false,
 });
 
+// TODO: hid requester/volunteer-specific attestations for respective roles
+function showAttestations (attestations : Attestations) {
+    return (
+        <div>
+            <Typography variant="h2">
+                User Attestations:
+            </Typography>
+            <Typography>
+                User is eighteen or older: {attestations.user_is_eighteen ? "true" : "false"} <br />
+                User accepts email communications from Lasagna Love:
+                    {attestations.user_accepted_email_communications ? "true" : "false"} <br />
+                Date requester accepted liability release: {attestations.requester_accepted_liability_release ?
+                     attestations.requester_accepted_liability_release : "(never accepted)"} <br />
+                Date volunteer accepted indemnity waiver: {attestations.volunteer_accepted_indemnity_waiver ?
+                    attestations.volunteer_accepted_indemnity_waiver : "(never accepted)"} <br />
+                Date volunteer accepted volunteer terms and conditions:
+                    {attestations.volunteer_accepted_volunteer_terms ?
+                        attestations.volunteer_accepted_volunteer_terms : "(never accepted)"} <br />
+                Date volunteer completed safety training: {attestations.volunteer_completed_safety_training ?
+                    attestations.volunteer_completed_safety_training : "(never completed)"}
+            </Typography>
+        </div>
+    )
+}
+
 function showRecipientInfo (recipientInfo: RecipientInfo) {
     return (
         <div>
@@ -24,9 +49,13 @@ function showRecipientInfo (recipientInfo: RecipientInfo) {
                 Recipient information:
             </Typography>
             <Typography>
+            Last delivery received: {recipientInfo.last_delivery_received ?
+               recipientInfo.last_delivery_received : "no deliveries received" } <br />
             Number of adults in household: {recipientInfo.adult_count} <br />
             Number of children in household: {recipientInfo.child_count} <br />
             Learned about Lasagna Love from: {recipientInfo.learned_about_from} <br />
+            Dietary restrictions: {recipientInfo.dietary_restrictions ?
+                recipientInfo.dietary_restrictions : "none"}
             </Typography>
         </div>
     )
@@ -39,11 +68,21 @@ function showVolunteerInfo (volunteerInfo : VolunteerInfo) {
                 Volunteer information:
             </Typography>
             <Typography>
-            Facebook profile name: {volunteerInfo.facebook_name} <br />
             Birthday: {volunteerInfo.birthday} <br />
+            Facebook profile name: {volunteerInfo.facebook_name} <br />
+            Organization volunteering with: {volunteerInfo.volunteering_with} <br />
+            Employer: {volunteerInfo.employer} <br />
             Gender identity: {volunteerInfo.gender_identity} <br />
             Maximum distance willing to travel to deliver: {volunteerInfo.max_travel_distance} <br />
             Maximum families per delivery: {volunteerInfo.families_per_delivery} <br />
+            Willing to accomodate extra requests: {volunteerInfo.accomodates_extra_requests ?
+                "true" : "false"} <br />
+            Show completed requests in portal by default: {volunteerInfo.show_completed_requests ?
+                "true" : "false"} <br />
+            Supported dietary restrictions: {volunteerInfo.allowable_dietary_restrictions ?
+                volunteerInfo.allowable_dietary_restrictions : "none"} <br />
+            Availability schedule: {volunteerInfo.available_schedule ?
+                "(display not supported)" : "(information unknown, not yet supported)"}
             </Typography>
         </div>
     )
@@ -86,21 +125,41 @@ export default function Profile() {
                         Current logged-in user
                     </Typography>
                     <Typography variant="h2">
-                        Some basic user info (not all)
+                        User information:
                     </Typography>
                     <Typography>
                         User ID: {userProfile?.id}<br />
                         Username: {userProfile?.username}<br />
-                        User roles: {userProfile?.roles}<br />
+                        Password: (hidden) <br />
+                        Email address: {userProfile?.email}<br />
+                        User roles: {userProfile?.roles ? userProfile.roles.toString() : ""}<br />
+                        <br />
                         First name: {userProfile?.given_name}<br />
+                        Middle / maiden name: {userProfile?.middle_or_maiden_name}<br />
                         Last name: {userProfile?.family_name}<br />
+                        Home phone: {userProfile?.home_phone}<br />
+                        Mobile phone: {userProfile?.mobile_phone}<br />
+                        Permission to contact at mobile phone regarding matches:
+                            {userProfile?.mobile_contact_permission ? "true" : "false"}<br />
+                        Permission to email Lasagna Love news and updates:
+                            {userProfile?.news_updates_permission ? "true" : "false"}<br />
+                        <br />
+                        Street address: {userProfile?.street_address ?
+                            userProfile.street_address.toString() : ""}<br />
+                        City: {userProfile?.city}<br />
+                        State / Province: {userProfile?.state_or_province}<br />
+                        Postal code: {userProfile?.postal_code}<br />
+                        Country: (Not yet supported)<br />
+                        <br />
+                        Profile created on: {userProfile?.creation_time}<br />
+                        Profile last updated: {userProfile?.last_update_time}<br />
+                        Email address verified: {userProfile?.email_validated ? "true" : "false"}<br />
+                        User is active: {userProfile?.active ? "true" : "false"}<br />
+                        User is paused: {userProfile?.paused ? "true" : "false"}<br />
+                        User pause end date: {userProfile?.paused_end_date ?
+                            userProfile?.paused_end_date : "(none)"}<br />
                     </Typography>
-                    <Typography variant="h2">
-                        User Attestations:
-                    </Typography>
-                    <Typography>
-                        User is eighteen or older: {userProfile?.attestations.user_is_eighteen ? "true" : "false"} <br />
-                    </Typography>
+                    { userProfile?.attestations ? showAttestations(userProfile.attestations) : "" }
                     { userProfile?.volunteer_info ? showVolunteerInfo(userProfile.volunteer_info) : "" }
                     { userProfile?.recipient_info ? showRecipientInfo(userProfile.recipient_info) : "" }
                 </CardContent>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -17,6 +17,38 @@ const MainHeader = dynamic(() => import("@/components/main_header"), {
   ssr: false,
 });
 
+function showRecipientInfo (recipientInfo: RecipientInfo) {
+    return (
+        <div>
+            <Typography variant="h2">
+                Recipient information:
+            </Typography>
+            <Typography>
+            Number of adults in household: {recipientInfo.adult_count} <br />
+            Number of children in household: {recipientInfo.child_count} <br />
+            Learned about Lasagna Love from: {recipientInfo.learned_about_from} <br />
+            </Typography>
+        </div>
+    )
+}
+
+function showVolunteerInfo (volunteerInfo : VolunteerInfo) {
+    return (
+        <div>
+            <Typography variant="h2">
+                Volunteer information:
+            </Typography>
+            <Typography>
+            Facebook profile name: {volunteerInfo.facebook_name} <br />
+            Birthday: {volunteerInfo.birthday} <br />
+            Gender identity: {volunteerInfo.gender_identity} <br />
+            Maximum distance willing to travel to deliver: {volunteerInfo.max_travel_distance} <br />
+            Maximum families per delivery: {volunteerInfo.families_per_delivery} <br />
+            </Typography>
+        </div>
+    )
+}
+
 export default function Profile() {
     const [userProfile, setUserProfile] = React.useState<Profile | undefined>(undefined);
     const [isLoading, setLoading] = React.useState(false);
@@ -69,6 +101,8 @@ export default function Profile() {
                     <Typography>
                         User is eighteen or older: {userProfile?.attestations.user_is_eighteen ? "true" : "false"} <br />
                     </Typography>
+                    { userProfile?.volunteer_info ? showVolunteerInfo(userProfile.volunteer_info) : "" }
+                    { userProfile?.recipient_info ? showRecipientInfo(userProfile.recipient_info) : "" }
                 </CardContent>
             </Card>
         </main>

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,7 +1,15 @@
 import axios, { AxiosResponse } from "axios";
+import jwt_decode from "jwt-decode";
 
 // TODO: un hard-code the URL string, obtain from elsewhere
 const API_URL = "http://localhost:8080/";
+
+interface BechamelAccessToken {
+    exp: number,
+    iat: number,
+    nbf: number,
+    userName: string
+}
 
 class AuthService {
     private storeTokens(loginResponse : AxiosResponse) {
@@ -55,10 +63,26 @@ class AuthService {
         }
     }
 
+    getCurrentUsername() {
+        var accessToken = localStorage.getItem("bechamel_access_token");
+        if (accessToken === "")
+            return "";
+        try {
+            var decodedToken = accessToken ?
+                jwt_decode<BechamelAccessToken>(accessToken) :
+                <BechamelAccessToken>{ userName: "" };
+            return decodedToken.userName
+        } catch (error) {
+            console.error(error);
+            alert("getCurrentUsername ERROR: " + error);
+            return "";
+        }
+    }
+
     logout() {
         localStorage.removeItem("bechamel_access_token");
         localStorage.removeItem("bechamel_refresh_token");
-        alert("You have successfully logged out.")
+        return true;
     }
 }
 

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,16 +1,20 @@
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import AuthService from './auth.service';
 import authHeader from './auth-header';
-import { ref } from 'yup';
+import { Attestations } from '@/model/Attestations';
+import { VolunteerInfo } from '@/model/VolunteerInfo';
+import { RecipientInfo } from '@/model/RecipientInfo';
+import { Profile } from '@/model/Profile';
 
 // TODO: un hard-code the URL string, obtain from elsewhere
 const API_URL = 'http://localhost:8080/';
 
 class UserService {
-    async getCurrentUserProfile() {
+    async getCurrentUserProfile() : Promise<Profile> {
         try {
             let response = await axios.get(API_URL + 'profile', { headers: authHeader() });
-            return response.data;
+            let userProfile : Profile = response.data;
+            return userProfile;
         } catch (error) {
             if (axios.isAxiosError(error)) {
                 const axiosErr = error as AxiosError;
@@ -21,7 +25,8 @@ class UserService {
                         await AuthService.refresh(refreshToken);
                         // Need to handle error, ideal would be to call recursively... but having issues
                         let retryResponse = await axios.get(API_URL + 'profile', { headers: authHeader() });
-                        return retryResponse.data;
+                        let userProfile : Profile = retryResponse.data;
+                        return userProfile;
                     }
                 } else {
                     console.error(error);
@@ -31,6 +36,7 @@ class UserService {
                 console.error(error);
                 alert("Error: " + error);
             }
+            return new Promise<Profile>(resolve => { });
         }
     }
 }

--- a/src/styles/MainHeader.module.css
+++ b/src/styles/MainHeader.module.css
@@ -1,0 +1,16 @@
+/* ----- Main header for logged-in users ----- */
+.main-header {
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    display: flex;
+    flex-direction: row;
+    justify-content: right;
+    align-items: center;
+    padding-bottom: 25px;
+    background-color: #fffaf7;
+    padding: 25px 20 25px;
+    flex-direction: row;
+    justify-content: right;
+    align-items: center;
+}

--- a/src/styles/MainHeader.module.css
+++ b/src/styles/MainHeader.module.css
@@ -7,7 +7,6 @@
   flex-direction: row;
   justify-content: right;
   align-items: center;
-  padding-bottom: 25px;
   background-color: #fffaf7;
   padding: 25px 20;
 }

--- a/src/styles/MainHeader.module.css
+++ b/src/styles/MainHeader.module.css
@@ -1,16 +1,13 @@
 /* ----- Main header for logged-in users ----- */
 .main-header {
-    width: 100%;
-    height: 100%;
-    overflow: auto;
-    display: flex;
-    flex-direction: row;
-    justify-content: right;
-    align-items: center;
-    padding-bottom: 25px;
-    background-color: #fffaf7;
-    padding: 25px 20 25px;
-    flex-direction: row;
-    justify-content: right;
-    align-items: center;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  display: flex;
+  flex-direction: row;
+  justify-content: right;
+  align-items: center;
+  padding-bottom: 25px;
+  background-color: #fffaf7;
+  padding: 25px 20;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 /* ----- GENERAL STYLES ----- */
 html,
 body,


### PR DESCRIPTION
* Adds the beginnings of a common navigation bar for logged-in users.
  The navigation bar looks for the username in the stored access JWT
  to populate the username in a menu button, and redirects users
  to login if it can't find a stored access JWT
* Adds a main landing page for users after they log in (/landing)
  which shows the common navigation bar
* Adds starting Profile and related data models for returned values
  from GET /profile Bechamel API calls. Updates getCurrentUserProfile()
  to return promise of the Profile interface so it can be used
  with type hinting in profile page
* Adds the common navigation bar to the profile page, and changes around
  the displayed profile information to show using the modeled Profile
  data object
* Adds a very basic logout page as a target for navigation menu logout option
* Adds jwt-decode package to project to parse stored access JWTs
* login page now waits for the login to succeed before redirecting user
* removes duplicate API call to GET /profile in profile page

**Known Issues**
* Handling of login failures is still suboptimal
* Main navbar is ugly and janky
* Linter issues are believed to be pre-existing issues from https://github.com/Lasagna-Love-Portal/project-ricotta/issues/42, could still use help in resolving these