### PR TITLE
Linter usage and issue fixups

### DIFF
--- a/.github/linters/.hadolint.yaml
+++ b/.github/linters/.hadolint.yaml
@@ -1,0 +1,3 @@
+ignored:
+  - DL3018  # don't flag apk add without pinned version, we pull in libc6-compat without
+  - DL3059  # don't flag consecutive RUN statements, these can be useful for readability

--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -2,8 +2,7 @@
 extends: default
 
 rules:
-  document-start:
-    present: false
+  document-start: disable
   new-lines: disable
   line-length:
     max: 120

--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -3,4 +3,9 @@ extends: default
 
 rules:
   document-start:
-    present: true
+    present: false
+  new-lines: disable
+  line-length:
+    max: 120
+    level: warning
+  comments-indentation: disable

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -6,7 +6,7 @@
 # https://github.com/github/super-linter
 name: Lint Code Base
 
-on:
+on: # yamllint disable-line rule:truthy
   push:
     branches: ["dev", "main", "mattkuznicki-ll/linter-issue-fixups"]
   pull_request:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -6,9 +6,9 @@
 # https://github.com/github/super-linter
 name: Lint Code Base
 
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   push:
-    branches: ["dev", "main", "mattkuznicki-ll/linter-issue-fixups"]
+    branches: ["dev", "main"]
   pull_request:
     branches: ["dev", "main"]
 jobs:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -8,7 +8,7 @@ name: Lint Code Base
 
 on:
   push:
-    branches: ["dev", "main", "mattkuznicki-ll/add-main-landing-area"]
+    branches: ["dev", "main", "mattkuznicki-ll/linter-issue-fixups"]
   pull_request:
     branches: ["dev", "main"]
 jobs:
@@ -29,3 +29,9 @@ jobs:
           DEFAULT_BRANCH: "dev"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: .*reference_materials/.*
+          # Currently the ts-standard linter cannot be coaxed to play nice
+          # with the tsconfig.json file - the ESLint config and tsconfig configs don't agree
+          # on the files to process.
+          # It breaks my heart to turn this off for the time being...
+          # See https://github.com/Lasagna-Love-Portal/project-ricotta/issues/42
+          VALIDATE_TYPESCRIPT_STANDARD: false

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,11 +70,31 @@ against your changes before making a pull request to dev or main.
 You can run this locally using Docker:
 
 1. Obtain the Super Linter Docker container:
-    `docker pull github/super-linter:latest`
-2. Invoke Docker to run the Super Linter against your project directory:
-    `docker run -e RUN_LOCAL=true -v [path-to-project]:/tmp/lint github/super-linter`
 
-Where [path-to-project] is the full path to your project.
+    `docker pull github/super-linter:latest`
+
+2. Invoke Docker to run the Super Linter against your project directory:
+
+    `docker run -e RUN_LOCAL=true -e FILTER_REGEX_EXCLUDE=.*reference_materials/.*
+    -v [path-to-project]:/tmp/lint github/super-linter`
+
+Where [path-to-project] is the path to your project. This can be a full or relative path. You can exclude the 'reference_materials' folder since items in there are not considered source or project code.
+
+For example, if you're currently in the top level project-ricotta directory you can run the linter with:
+
+    `docker run -e RUN_LOCAL=true -e FILTER_REGEX_EXCLUDE=.*reference_materials/.* -v .:/tmp/lint github/super-linter`
+
+To narrow the files to lint, pass the file(s) to run as a regular expression
+in the environment variable FILTER_REGEX_INCLUDE. Or to exclude file(s) pass an appropriate
+regular expression in the FILTER_REGEX_EXCLUDE environment variable.
+
+For example, to only lint the file DEVELOPMENT.md in the top level directory:
+
+   `docker run -e RUN_LOCAL=true -e FILTER_REGEX_INCLUDE=DEVELOPMENT.md -v .:/tmp/lint github/super-linter`
+
+Use UNIX-style paths with forward-slash \/ characters as path separators.
+See the [super-linter GitHub repository](https://github.com/github/super-linter/blob/main/README.md#filter-linted-files)
+for more information on how to specify files for super-linter runs.
 
 ## Architecture
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -67,30 +67,30 @@ We encourage contributors to use Docker if possible to keep the build and runtim
 
 This repository uses github's Super Linter and we encourage running the linter
 against your changes before making a pull request to dev or main.
-You can run this locally using Docker:
+You can run this locally using Docker using the supplied `super-linter.env` collection of environment variables
+and your own:
 
 1. Obtain the Super Linter Docker container:
 
     `docker pull github/super-linter:latest`
 
-2. Invoke Docker to run the Super Linter against your project directory:
+2. Invoke Docker to run the Super Linter against your project directory with the included environment variables:
 
-    `docker run -e RUN_LOCAL=true -e FILTER_REGEX_EXCLUDE=.*reference_materials/.*
-    -v [path-to-project]:/tmp/lint github/super-linter`
+    `docker run --env-file super-linter.env -v [path-to-project]:/tmp/lint github/super-linter`
 
-Where [path-to-project] is the path to your project. This can be a full or relative path. You can exclude the 'reference_materials' folder since items in there are not considered source or project code.
-
+Where [path-to-project] is the path to your project. This can be a full or relative path.
 For example, if you're currently in the top level project-ricotta directory you can run the linter with:
 
-    `docker run -e RUN_LOCAL=true -e FILTER_REGEX_EXCLUDE=.*reference_materials/.* -v .:/tmp/lint github/super-linter`
+    `docker run --env-file super-linter.env -v .:/tmp/lint github/super-linter`
 
-To narrow the files to lint, pass the file(s) to run as a regular expression
-in the environment variable FILTER_REGEX_INCLUDE. Or to exclude file(s) pass an appropriate
-regular expression in the FILTER_REGEX_EXCLUDE environment variable.
+To narrow the files to lint, pass the file(s) to run as a regular expression in the environment variable
+`FILTER_REGEX_INCLUDE`. To exclude file(s) pass an appropriate addition to the
+regular expression in the FILTER_REGEX_EXCLUDE environment variable entry in the `super-linter.env` file
+or supply the regular expression for the files you wish to include on the command-line with the `-e` flag.
 
 For example, to only lint the file DEVELOPMENT.md in the top level directory:
 
-   `docker run -e RUN_LOCAL=true -e FILTER_REGEX_INCLUDE=DEVELOPMENT.md -v .:/tmp/lint github/super-linter`
+   `docker run --env-file super-linter.env -e FILTER_REGEX_INCLUDE=DEVELOPMENT.md -v .:/tmp/lint github/super-linter`
 
 Use UNIX-style paths with forward-slash \/ characters as path separators.
 See the [super-linter GitHub repository](https://github.com/github/super-linter/blob/main/README.md#filter-linted-files)

--- a/docker-compose.prod-like.yml
+++ b/docker-compose.prod-like.yml
@@ -1,2 +1,2 @@
-# This file is an override to the development / default docker-compose. 
+# This file is an override to the development / default docker-compose.
 # It changes the target docker stage from dev to prod. It also removes the volume mount.

--- a/super-linter.env
+++ b/super-linter.env
@@ -1,0 +1,3 @@
+RUN_LOCAL=true
+VALIDATE_TYPESCRIPT_STANDARD=false
+FILTER_REGEX_EXCLUDE=.*reference_materials/.*


### PR DESCRIPTION
* Disables the TYPESCRIPT_STANDARD validator in the Github action -
  currently unable to get its ESLint and the super-linter default tsconfig
  or any supplied tsconfig.json file to agree on file list to scan
* Add more information to developer documentation about running linter locally,
including an environment variable script to use for easier invocations
* Loosen some YAML rules a bit and fix some YAML file issues
* Adds a Dockerfile parsing rules file to loosen a couple rules
* Code fixes as prompted by linter to reduce a bit of duplication;
  a bit of data typing added along the way